### PR TITLE
 Windows display scaling ignored by default (x64 build) in v6.2.7 #216

### DIFF
--- a/Source/Main.pas
+++ b/Source/Main.pas
@@ -2161,6 +2161,13 @@ begin
   MinFileListWidth := AdvPageFilelist.Constraints.MinWidth;
   AdvPageFilelist.Constraints.MinWidth := 0;
 
+// Scaling for the menu items.
+// Note: When DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 is active and a style <> Windows
+//       The (sub)items are larger than the items.
+//       Could this be a bug in themes?
+  if (Scaled) then
+    Screen.MenuFont.Size := MulDiv(Screen.MenuFont.Size, Monitor.PixelsPerInch, Screen.DefaultPixelsPerInch);
+
   ReadGUIini;
 
   // Create Bread Crumb

--- a/Source/UnitDpiAwareness.pas
+++ b/Source/UnitDpiAwareness.pas
@@ -56,7 +56,7 @@ begin
         Check(DpiAware);
     end
     else
-      SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE); // Dont check default
+      SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE); // Dont check default
   end
   else if CheckWin32Version(6, 3) then  // Windows 8.1
   begin
@@ -72,7 +72,7 @@ begin
         Check(DpiAware);
     end
     else
-      SetProcessDpiAwareness(TProcessDpiAwareness.PROCESS_SYSTEM_DPI_AWARE);  // Dont check default
+      SetProcessDpiAwareness(TProcessDpiAwareness.PROCESS_PER_MONITOR_DPI_AWARE);  // Dont check default
   end;
 end;
 


### PR DESCRIPTION
Changed defaults.
Scale MenuItems